### PR TITLE
Give events to subwidgets first if needed; Use onResize on UI

### DIFF
--- a/sources/plugin/UISpectralAnalyzer.cpp
+++ b/sources/plugin/UISpectralAnalyzer.cpp
@@ -457,6 +457,7 @@ UISpectralAnalyzer::UISpectralAnalyzer()
     fResizeHandle->toFront();
     fMainToolBar->toFront();
 
+    // setup initial size
     doResize(getWidth(), getHeight());
 }
 

--- a/sources/plugin/UISpectralAnalyzer.cpp
+++ b/sources/plugin/UISpectralAnalyzer.cpp
@@ -453,7 +453,11 @@ UISpectralAnalyzer::UISpectralAnalyzer()
         setSize(newSize);
     };
 
-    uiReshape(getWidth(), getHeight());
+    // make order explicit (widgets on top of the stack are handled first)
+    fResizeHandle->toFront();
+    fMainToolBar->toFront();
+
+    doResize(getWidth(), getHeight());
 }
 
 UISpectralAnalyzer::~UISpectralAnalyzer()
@@ -545,10 +549,7 @@ void UISpectralAnalyzer::uiIdle()
     }
 }
 
-/**
-  Window reshape function, called when the parent window is resized.
-*/
-void UISpectralAnalyzer::uiReshape(uint width, uint height)
+void UISpectralAnalyzer::doResize(uint width, uint height)
 {
     fSpectrumView->setAbsolutePos(0, 0);
     fSpectrumView->setSize(width, height);
@@ -585,6 +586,9 @@ void UISpectralAnalyzer::onNanoDisplay()
 
 bool UISpectralAnalyzer::onMouse(const MouseEvent &ev)
 {
+    if (UI::onMouse(ev))
+        return true;
+
     DGL::Point<int> mpos{int(ev.pos.getX() + 0.5), int(ev.pos.getY() + 0.5)};
 
     if (fMode == kModeScale && ev.press && ev.button == 1) {
@@ -636,6 +640,9 @@ bool UISpectralAnalyzer::onMouse(const MouseEvent &ev)
 
 bool UISpectralAnalyzer::onMotion(const MotionEvent &ev)
 {
+    if (UI::onMotion(ev))
+        return true;
+
     DGL::Point<int> mpos{int(ev.pos.getX() + 0.5), int(ev.pos.getY() + 0.5)};
 
     switch (fMode) {
@@ -660,6 +667,12 @@ bool UISpectralAnalyzer::onMotion(const MotionEvent &ev)
     }
 
     return false;
+}
+
+void UISpectralAnalyzer::onResize(const ResizeEvent& ev)
+{
+    UI::onResize(ev);
+    doResize(ev.size.getWidth(), ev.size.getHeight());
 }
 
 // -----------------------------------------------------------------------

--- a/sources/plugin/UISpectralAnalyzer.hpp
+++ b/sources/plugin/UISpectralAnalyzer.hpp
@@ -55,11 +55,12 @@ protected:
     void sampleRateChanged(double newSampleRate) override;
 
     void uiIdle() override;
-    void uiReshape(uint width, uint height) override;
+    void doResize(uint width, uint height);
 
     void onNanoDisplay() override;
     bool onMouse(const MouseEvent &ev) override;
     bool onMotion(const MotionEvent &ev) override;
+    void onResize(const ResizeEvent& ev) override;
 
 protected:
     void onToolBarItemClicked(int id) override;

--- a/sources/ui/components/FloatingWindow.cpp
+++ b/sources/ui/components/FloatingWindow.cpp
@@ -3,7 +3,7 @@
 #include "Window.hpp"
 
 FloatingWindow::FloatingWindow(Widget *group, ColorPalette &palette)
-    : NanoWidget(group),
+    : NanoSubWidget(group),
       fPalette(palette)
 {
 }
@@ -61,6 +61,9 @@ void FloatingWindow::onPositionChanged(const PositionChangedEvent &ev)
 
 bool FloatingWindow::onMouse(const MouseEvent &ev)
 {
+    if (NanoSubWidget::onMouse(ev))
+        return true;
+
     if (ev.press && ev.button == 1) {
         const int w = getWidth();
         const int h = getHeight();
@@ -87,6 +90,9 @@ bool FloatingWindow::onMouse(const MouseEvent &ev)
 
 bool FloatingWindow::onMotion(const MotionEvent &ev)
 {
+    if (NanoSubWidget::onMotion(ev))
+        return true;
+
     if (fIsDragging) {
         DGL::Point<int> orig = fDragMouseOrigin;
         int curx = ev.pos.getX() + getAbsoluteX();

--- a/sources/ui/components/MainToolBar.cpp
+++ b/sources/ui/components/MainToolBar.cpp
@@ -8,6 +8,7 @@ MainToolBar::MainToolBar(Widget *group, ColorPalette &palette)
     : NanoSubWidget(group),
       fPalette(palette)
 {
+    setHeight(40);
 }
 
 void MainToolBar::addButton(int id, const char *label, const char *icon)

--- a/sources/ui/components/MainToolBar.cpp
+++ b/sources/ui/components/MainToolBar.cpp
@@ -5,7 +5,7 @@
 #include "Window.hpp"
 
 MainToolBar::MainToolBar(Widget *group, ColorPalette &palette)
-    : NanoWidget(group),
+    : NanoSubWidget(group),
       fPalette(palette)
 {
 }
@@ -89,7 +89,7 @@ void MainToolBar::onNanoDisplay()
 
 void MainToolBar::onResize(const ResizeEvent &ev)
 {
-    (void)ev;
+    NanoSubWidget::onResize(ev);
     updatePositionsAndSizes();
     repaint();
 }

--- a/sources/ui/components/ResizeHandle.cpp
+++ b/sources/ui/components/ResizeHandle.cpp
@@ -5,7 +5,7 @@
 #include "Window.hpp"
 
 ResizeHandle::ResizeHandle(Widget *group, const ColorPalette &palette)
-    : NanoWidget(group),
+    : NanoSubWidget(group),
       fPalette(palette)
 {
 }

--- a/sources/ui/components/SelectionRectangle.cpp
+++ b/sources/ui/components/SelectionRectangle.cpp
@@ -3,7 +3,7 @@
 #include "Window.hpp"
 
 SelectionRectangle::SelectionRectangle(Widget *group, ColorPalette &palette)
-    : NanoWidget(group),
+    : NanoSubWidget(group),
       fPalette(palette)
 {
 }

--- a/sources/ui/components/Slider.cpp
+++ b/sources/ui/components/Slider.cpp
@@ -48,10 +48,7 @@ bool Slider::onMouse(const MouseEvent &event)
     DGL::Point<int> mpos{int(event.pos.getX() + 0.5), int(event.pos.getY() + 0.5)};
 
     if (!fIsDragging && event.press && event.button == 1) {
-        bool insideX = mpos.getX() >= 0 && (unsigned)mpos.getX() < wsize.getWidth();
-        bool insideY = mpos.getY() >= 0 && (unsigned)mpos.getY() < wsize.getHeight();
-
-        if (!insideX || !insideY)
+        if (!contains(event.pos))
             return false;
 
         fIsDragging = true;
@@ -87,14 +84,7 @@ bool Slider::onMotion(const MotionEvent &event)
 
 bool Slider::onScroll(const ScrollEvent &event)
 {
-    DGL::Size<uint> wsize = getSize();
-    DGL::Point<int> mpos{int(event.pos.getX() + 0.5), int(event.pos.getY() + 0.5)};
-
-    bool inside =
-        mpos.getX() >= 0 && mpos.getY() >= 0 &&
-        (unsigned)mpos.getX() < wsize.getWidth() && (unsigned)mpos.getY() < wsize.getHeight();
-
-    if (inside) {
+    if (contains(event.pos)) {
         double amount = event.delta.getX() - event.delta.getY();
         setValue(fValue + amount * (fValueBound2 - fValueBound1) / fNumSteps);
         return true;

--- a/sources/ui/components/Slider.cpp
+++ b/sources/ui/components/Slider.cpp
@@ -7,7 +7,7 @@
 
 ///
 Slider::Slider(Widget *group, const ColorPalette &palette)
-    : NanoWidget(group),
+    : NanoSubWidget(group),
       fPalette(palette)
 {
 }

--- a/sources/ui/components/SpectrumView.cpp
+++ b/sources/ui/components/SpectrumView.cpp
@@ -22,7 +22,7 @@ static double ftom(double f)
 
 ///
 SpectrumView::SpectrumView(Widget *parent, const ColorPalette &palette)
-    : NanoWidget(parent),
+    : NanoSubWidget(parent),
       fColorPalette(palette)
 {
 }

--- a/sources/ui/components/SpinBoxChooser.cpp
+++ b/sources/ui/components/SpinBoxChooser.cpp
@@ -5,7 +5,7 @@
 #include "Window.hpp"
 
 SpinBoxChooser::SpinBoxChooser(Widget *group, const ColorPalette &palette)
-    : NanoWidget(group),
+    : NanoSubWidget(group),
       fPalette(palette)
 {
     updateLayout();
@@ -117,7 +117,7 @@ void SpinBoxChooser::onNanoDisplay()
 
 void SpinBoxChooser::onResize(const ResizeEvent &ev)
 {
-    (void)ev;
+    NanoSubWidget::onResize(ev);
     updateLayout();
 }
 

--- a/sources/ui/components/TextLabel.cpp
+++ b/sources/ui/components/TextLabel.cpp
@@ -3,7 +3,7 @@
 #include "plugin/ColorPalette.h"
 
 TextLabel::TextLabel(Widget *group, const ColorPalette &palette)
-    : NanoWidget(group),
+    : NanoSubWidget(group),
       fPalette(palette)
 {
 }


### PR DESCRIPTION
Initial fixup, main issue was on DPF side.
Some comments:

- uiReshape is used to setup OpenGL things, but you were using it as a resize callback without the UI::uiReshape handler, I changed this to just use the regular onResize
- if a class has child widgets, we need to give events to them first so they have a chance to catch/handle them first

The reshape/resize change makes the main toolbar not appear on the correct position at the start, dont know why yet..

Also, something is still wrong on DPF side regarding position of sub-sub widgets. This makes the slider not work here.
But note that you dont need to compare coordinates yourself, each widget has a `contains` helper method for this, ie:
```
bool MyWidget::onMouse(const MouseEvent& ev)
{
    if (ev.press && contains(ev.pos))
    {
    }
...
```

I will have to see what is wrong with the sub-sub widget positioning, I thought I handled that already...
